### PR TITLE
[DO NOT MERGE] Testing validator_service.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ docs/_build
 # IDE crud
 .idea
 *.iml
+.vscode

--- a/pyethapp/eth_service.py
+++ b/pyethapp/eth_service.py
@@ -170,9 +170,7 @@ class ChainService(WiredService):
 
         genesis_data = sce.get('genesis_data', {})
         if not genesis_data:
-            # genesis_data = casper_utils.make_casper_genesis(ALLOC, 10, 100, 0.02, 0.002)
             genesis_data = casper_utils.make_casper_genesis(env)
-        #     genesis_data = mk_genesis_data(env)
         self.chain = Chain(
             genesis=genesis_data,
             reset_genesis=True,

--- a/pyethapp/eth_service.py
+++ b/pyethapp/eth_service.py
@@ -166,21 +166,18 @@ class ChainService(WiredService):
         super(ChainService, self).__init__(app)
         log.info('initializing chain')
         coinbase = app.services.accounts.coinbase
-        # env = Env(self.db, sce['block'])
+        env = Env(self.db, sce['block'])
 
-        # genesis_data = sce.get('genesis_data', {})
-        # if not genesis_data:
+        genesis_data = sce.get('genesis_data', {})
+        if not genesis_data:
+            # genesis_data = casper_utils.make_casper_genesis(ALLOC, 10, 100, 0.02, 0.002)
+            genesis_data = casper_utils.make_casper_genesis(env)
         #     genesis_data = mk_genesis_data(env)
-        # self.chain = Chain(
-        #     env=env, genesis=genesis_data, coinbase=coinbase,
-        #     new_head_cb=self._on_new_head)
-        ALLOC = {}
-        # TODO: Remove this dumb default alloc
-        ALLOC[decode_hex('7d577a597b2742b498cb5cf0c26cdcd726d39e6e')] = {'balance': 50000*10**19}
-        ALLOC[decode_hex('b96611e02f9eff3c8afc6226d4ebfa81a821547c')] = {'balance': 50000*10**19}
-        ALLOC[decode_hex('b42e5cafe87d951c5cf0022bfdab06fe56ba2ad2')] = {'balance': 5 * 10**9 * 10**19}
-        genesis_data = casper_utils.make_casper_genesis(ALLOC, 10, 100, 0.02, 0.002)
-        self.chain = Chain(genesis=genesis_data, reset_genesis=True, coinbase=coinbase, new_head_cb=self._on_new_head)
+        self.chain = Chain(
+            genesis=genesis_data,
+            reset_genesis=True,
+            coinbase=coinbase,
+            new_head_cb=self._on_new_head)
         header = self.chain.state.prev_headers[0]
         log.info('chain at', number=header.number)
         if 'genesis_hash' in sce:

--- a/pyethapp/tests/test_validator_service.py
+++ b/pyethapp/tests/test_validator_service.py
@@ -37,7 +37,6 @@ class AccountsServiceMock(BaseService):
         self.coinbase = mock_address
 
     def find(self, address):
-
         assert address == encode_hex(tester.accounts[0])
         return mock_address
 
@@ -216,6 +215,8 @@ def test_login_sequence(test_app):
     # One more epoch and the vote_frac has a value (since it requires there
     # to be at least one vote for both the current and the prev epoch)
     test_app.mine_to_next_epoch()
+    t = tester.State(v.chain.state.ephemeral_clone())
+    c = tester.ABIContract(t, casper_utils.casper_abi, v.chain.casper_address)
     assert c.get_current_epoch() == 4
 
     # One more block to mine the vote
@@ -237,5 +238,14 @@ def test_double_login(test_app):
 def test_login_logout_login(test_app):
     pass
 
-def catch_violation(test_app):
+# Test slashing conditions--make sure that we don't violate them, and also
+# make sure that we can catch slashable behavior on the part of another validator.
+
+def test_prevent_double_vote(test_app):
+    pass
+
+def test_no_surround(test_app):
+    pass
+
+def test_catch_violation(test_app):
     pass

--- a/pyethapp/tests/test_validator_service.py
+++ b/pyethapp/tests/test_validator_service.py
@@ -38,9 +38,15 @@ def test_app(request, tmpdir):
                 'GENESIS_GAS_LIMIT': 3141592,
                 'GENESIS_INITIAL_ALLOC': {
                     encode_hex(tester.accounts[0]): {'balance': 10**24},
-                }
+                },
+                # Casper FFG stuff
+                'EPOCH_LENGTH': 10,
+                'WITHDRAWAL_DELAY': 100,
+                'BASE_INTEREST_FACTOR': 0.02,
+                'BASE_PENALTY_FACTOR': 0.002,
             }
         },
+        # 'genesis_data': {},
         # 'jsonrpc': {'listen_port': 29873},
         'validate': [encode_hex(tester.accounts[0])],
     }
@@ -70,9 +76,9 @@ def test_generate_valcode(test_app):
     test = TestLangHybrid(5, 25, 0.02, 0.002)
     test.parse('B B')
 
-    # Create a smart chain object
+    # Create a smart chain object: this ties the chain used in the tester
+    # to the validator chain.
     test.t.chain = hybrid_casper_chain.Chain(genesis=test.genesis, new_head_cb=test_app.services.validator.on_new_head)
-
     test_app.services.chain.chain = test.t.chain
     test.parse('B1')
 

--- a/pyethapp/tests/test_validator_service.py
+++ b/pyethapp/tests/test_validator_service.py
@@ -1,0 +1,76 @@
+from ethereum.config import default_config
+from pyethapp.config import update_config_with_defaults, get_default_config
+from ethereum.slogging import get_logger
+from ethereum.tools import tester
+import pytest
+import shutil
+import tempfile
+from devp2p.app import BaseApp
+from pyethapp.eth_service import ChainService
+from pyethapp.db_service import DBService
+from pyethapp.accounts import Account, AccountsService
+from pyethapp.validator_service import ValidatorService
+from ethereum.utils import encode_hex
+
+log = get_logger('tests.validator_service')
+
+@pytest.fixture()
+def app(request):
+    config = {
+        'accounts': {
+            'keystore_dir': tempfile.mkdtemp(),
+        },
+        'data_dir': str(tempfile.gettempdir()),
+        'db': {'implementation': 'EphemDB'},
+        'pow': {'activated': False},
+        'p2p': {
+            'min_peers': 0,
+            'max_peers': 0,
+            'listen_port': 29873
+        },
+        'discovery': {
+            'boostrap_nodes': [],
+            'listen_port': 29873
+        },
+        'eth': {
+            'block': {  # reduced difficulty, increased gas limit, allocations to test accounts
+                'GENESIS_DIFFICULTY': 1,
+                'BLOCK_DIFF_FACTOR': 2,  # greater than difficulty, thus difficulty is constant
+                'GENESIS_GAS_LIMIT': 3141592,
+                'GENESIS_INITIAL_ALLOC': {
+                    encode_hex(tester.accounts[0]): {'balance': 10**24},
+                }
+            }
+        },
+        'jsonrpc': {'listen_port': 29873},
+        'validate': [encode_hex(tester.accounts[0])],
+    }
+
+    services = [
+        DBService,
+        # AccountsService,
+        ChainService,
+        ValidatorService,
+        ]
+    update_config_with_defaults(config, get_default_config([BaseApp] + services))
+    update_config_with_defaults(config, {'eth': {'block': default_config}})
+    app = BaseApp(config)
+
+    # Add AccountsService first and initialize with coinbase account
+    AccountsService.register_with_app(app)
+    app.services.accounts.add_account(Account.new('', tester.keys[0]), store=False)
+
+    for service in services:
+        service.register_with_app(app)
+
+    def fin():
+        # cleanup temporary keystore directory
+        assert app.config['accounts']['keystore_dir'].startswith(tempfile.gettempdir())
+        shutil.rmtree(app.config['accounts']['keystore_dir'])
+        log.debug('cleaned temporary keystore dir', dir=app.config['accounts']['keystore_dir'])
+    request.addfinalizer(fin)
+
+    return app
+
+def test_foo(app):
+    assert True

--- a/pyethapp/tests/test_validator_service.py
+++ b/pyethapp/tests/test_validator_service.py
@@ -1,26 +1,87 @@
-from ethereum.config import default_config
-from pyethapp.config import update_config_with_defaults, get_default_config
-from ethereum.slogging import get_logger
-from ethereum.tools import tester
+from itertools import count
 import pytest
 import shutil
 import tempfile
-from devp2p.app import BaseApp
+from devp2p.service import BaseService
+from ethereum.config import default_config
+from pyethapp.config import update_config_with_defaults, get_default_config
+from ethereum.slogging import get_logger, configure_logging
+from ethereum.tools import tester
+from ethereum.pow.ethpow import mine
+from ethereum.tests.hybrid_casper.testing_lang import TestLangHybrid
+from ethereum.utils import encode_hex
+# from devp2p.app import BaseApp
+from pyethapp.app import EthApp
 from pyethapp.eth_service import ChainService
 from pyethapp.db_service import DBService
 from pyethapp.accounts import Account, AccountsService
 from pyethapp.validator_service import ValidatorService
-from ethereum.utils import encode_hex
+from pyethapp.pow_service import PoWService
 
 log = get_logger('tests.validator_service')
+configure_logging('validator:debug')
+
+class PeerManagerMock(BaseService):
+    name = 'peermanager'
+
+    def broadcast(*args, **kwargs):
+        pass
 
 @pytest.fixture()
-def app(request):
+def test_app(request, tmpdir):
+    class TestApp(EthApp):
+
+        # def start(self):
+        #     super(TestApp, self).start()
+        #     log.debug('adding test accounts')
+        #     # high balance account
+        #     # self.services.accounts.add_account(Account.new('', tester.keys[0]), store=False)
+        #     # # low balance account
+        #     # self.services.accounts.add_account(Account.new('', tester.keys[1]), store=False)
+        #     # # locked account
+        #     # locked_account = Account.new('', tester.keys[2])
+        #     # locked_account.lock()
+        #     # self.services.accounts.add_account(locked_account, store=False)
+        #     assert set(acct.address for acct in self.services.accounts) == set(tester.accounts[:1])
+
+        def mine_next_block(self):
+            """Mine until a valid nonce is found.
+
+            :returns: the new head
+            """
+            log.debug('mining next block')
+            block = self.services.chain.head_candidate
+            chain = self.services.chain.chain
+            head_number = chain.head.number
+            delta_nonce = 10**6
+            for start_nonce in count(0, delta_nonce):
+                bin_nonce, mixhash = mine(block.number, block.difficulty, block.mining_hash,
+                                          start_nonce=start_nonce, rounds=delta_nonce)
+                if bin_nonce:
+                    break
+            self.services.chain.add_mined_block(block)
+            self.services.pow.recv_found_nonce(bin_nonce, mixhash, block.mining_hash)
+            if len(chain.time_queue) > 0:
+                # If we mine two blocks within one second, pyethereum will
+                # force the new block's timestamp to be in the future (see
+                # ethereum1_setup_block()), and when we try to add that block
+                # to the chain (via Chain.add_block()), it will be put in a
+                # queue for later processing. Since we need to ensure the
+                # block has been added before we continue the test, we
+                # have to manually process the time queue.
+                log.debug('block mined too fast, processing time queue')
+                chain.process_time_queue(new_time=block.timestamp)
+            log.debug('block mined')
+            assert chain.head.difficulty == 1
+            assert chain.head.number == head_number + 1
+            return chain.head
+
     config = {
-        'accounts': {
-            'keystore_dir': tempfile.mkdtemp(),
-        },
-        'data_dir': str(tempfile.gettempdir()),
+        # 'accounts': {
+        #     'keystore_dir': tempfile.mkdtemp(),
+        # },
+        # 'data_dir': str(tempfile.gettempdir()),
+        'data_dir': str(tmpdir),
         'db': {'implementation': 'EphemDB'},
         'pow': {'activated': False},
         'p2p': {
@@ -44,17 +105,21 @@ def app(request):
         },
         'jsonrpc': {'listen_port': 29873},
         'validate': [encode_hex(tester.accounts[0])],
+        # 'validate': [tester.accounts[0]],
+        # 'validate': [],
     }
 
     services = [
         DBService,
         # AccountsService,
         ChainService,
+        PoWService,
+        PeerManagerMock,
         ValidatorService,
         ]
-    update_config_with_defaults(config, get_default_config([BaseApp] + services))
+    update_config_with_defaults(config, get_default_config([TestApp] + services))
     update_config_with_defaults(config, {'eth': {'block': default_config}})
-    app = BaseApp(config)
+    app = TestApp(config)
 
     # Add AccountsService first and initialize with coinbase account
     AccountsService.register_with_app(app)
@@ -64,13 +129,24 @@ def app(request):
         service.register_with_app(app)
 
     def fin():
-        # cleanup temporary keystore directory
-        assert app.config['accounts']['keystore_dir'].startswith(tempfile.gettempdir())
-        shutil.rmtree(app.config['accounts']['keystore_dir'])
-        log.debug('cleaned temporary keystore dir', dir=app.config['accounts']['keystore_dir'])
+        log.debug('stopping test app')
+        app.stop()
+        # # cleanup temporary keystore directory
+        # assert app.config['accounts']['keystore_dir'].startswith(tempfile.gettempdir())
+        # shutil.rmtree(app.config['accounts']['keystore_dir'])
+        # log.debug('cleaned temporary keystore dir', dir=app.config['accounts']['keystore_dir'])
     request.addfinalizer(fin)
 
     return app
 
-def test_foo(app):
+def test_generate_valcode(test_app):
+    # test = TestLangHybrid(5, 25, 0.02, 0.002)
+    # test.parse('B B')
+    # app.services.validator.chain = test.t.chain
+    # app.services.validator.chain.on_new_head_cbs.append(app.services.validator.on_new_head)
+    # test.parse('B1')
+    # test_chain = tester.Chain()
+    # test_chain.mine(30)
+    test_app.mine_next_block()
+
     assert True

--- a/pyethapp/tests/test_validator_service.py
+++ b/pyethapp/tests/test_validator_service.py
@@ -1,5 +1,4 @@
 from itertools import count
-import functools
 import pytest
 import shutil
 import tempfile
@@ -18,7 +17,7 @@ from pyethapp.validator_service import ValidatorService
 from pyethapp.pow_service import PoWService
 
 log = get_logger('tests.validator_service')
-configure_logging('validator:debug,eth.chainservice:debug')
+configure_logging('validator:debug,eth.chainservice:debug,eth.pb.tx:debug')
 
 class ChainServiceMock(BaseService):
     name = 'chain'
@@ -107,19 +106,12 @@ def test_app(request, tmpdir, test):
     return app
 
 def test_generate_valcode(test, test_app):
-    
     # Link the mock ChainService to the tester object. This is the interface between
     # pyethapp and pyethereum's test interface.
-    # test_app.services.chainservice.set_tester(test.t)
-
-    # test.parse('B B')
 
     # Create a smart chain object: this ties the chain used in the tester
     # to the validator chain.
-    # test.t.chain = hybrid_casper_chain.Chain(genesis=test.genesis, new_head_cb=test_app.services.validator.on_new_head)
-    # test_app.services.chain.chain = test.t.chain
-    # test_app.chain = test.t.chain
     test_app.chain = test.t.chain = test_app.services.chain.chain
-    test.parse('B')
+    test.parse('B B B')
 
     assert True

--- a/pyethapp/tests/test_validator_service.py
+++ b/pyethapp/tests/test_validator_service.py
@@ -8,7 +8,6 @@ from pyethapp.config import update_config_with_defaults, get_default_config
 from ethereum.slogging import get_logger, configure_logging
 from ethereum.hybrid_casper import chain as hybrid_casper_chain
 from ethereum.tools import tester
-from ethereum.pow.ethpow import mine
 from ethereum.tests.hybrid_casper.testing_lang import TestLangHybrid
 from ethereum.utils import encode_hex
 from pyethapp.app import EthApp
@@ -29,52 +28,9 @@ class PeerManagerMock(BaseService):
 
 @pytest.fixture()
 def test_app(request, tmpdir):
-    class TestApp(EthApp):
-        def mine_next_block(self):
-            """Mine until a valid nonce is found.
-
-            :returns: the new head
-            """
-            log.debug('mining next block')
-            block = self.services.chain.head_candidate
-            chain = self.services.chain.chain
-            head_number = chain.head.number
-            delta_nonce = 10**6
-            for start_nonce in count(0, delta_nonce):
-                bin_nonce, mixhash = mine(block.number, block.difficulty, block.mining_hash,
-                                          start_nonce=start_nonce, rounds=delta_nonce)
-                if bin_nonce:
-                    break
-            self.services.chain.add_mined_block(block)
-            self.services.pow.recv_found_nonce(bin_nonce, mixhash, block.mining_hash)
-            if len(chain.time_queue) > 0:
-                # If we mine two blocks within one second, pyethereum will
-                # force the new block's timestamp to be in the future (see
-                # ethereum1_setup_block()), and when we try to add that block
-                # to the chain (via Chain.add_block()), it will be put in a
-                # queue for later processing. Since we need to ensure the
-                # block has been added before we continue the test, we
-                # have to manually process the time queue.
-                log.debug('block mined too fast, processing time queue')
-                chain.process_time_queue(new_time=block.timestamp)
-            log.debug('block mined')
-            assert chain.head.difficulty == 1
-            assert chain.head.number == head_number + 1
-            return chain.head
-
     config = {
         'data_dir': str(tmpdir),
         'db': {'implementation': 'EphemDB'},
-        'pow': {'activated': False},
-        'p2p': {
-            'min_peers': 0,
-            'max_peers': 0,
-            'listen_port': 29873
-        },
-        'discovery': {
-            'boostrap_nodes': [],
-            'listen_port': 29873
-        },
         'eth': {
             'block': {  # reduced difficulty, increased gas limit, allocations to test accounts
                 'GENESIS_DIFFICULTY': 1,
@@ -85,7 +41,7 @@ def test_app(request, tmpdir):
                 }
             }
         },
-        'jsonrpc': {'listen_port': 29873},
+        # 'jsonrpc': {'listen_port': 29873},
         'validate': [encode_hex(tester.accounts[0])],
     }
 
@@ -93,13 +49,13 @@ def test_app(request, tmpdir):
         DBService,
         # AccountsService,
         ChainService,
-        PoWService,
+        # PoWService,
         PeerManagerMock,
         ValidatorService,
         ]
-    update_config_with_defaults(config, get_default_config([TestApp] + services))
+    update_config_with_defaults(config, get_default_config([EthApp] + services))
     update_config_with_defaults(config, {'eth': {'block': default_config}})
-    app = TestApp(config)
+    app = EthApp(config)
 
     # Add AccountsService first and initialize with coinbase account
     AccountsService.register_with_app(app)
@@ -108,12 +64,6 @@ def test_app(request, tmpdir):
     for service in services:
         service.register_with_app(app)
 
-    def fin():
-        log.debug('stopping test app')
-        app.stop()
-    request.addfinalizer(fin)
-
-    # app.start()
     return app
 
 def test_generate_valcode(test_app):
@@ -123,16 +73,7 @@ def test_generate_valcode(test_app):
     # Create a smart chain object
     test.t.chain = hybrid_casper_chain.Chain(genesis=test.genesis, new_head_cb=test_app.services.validator.on_new_head)
 
-    # print(test.t.chain)
-    # test.t.chain.on_new_head_cbs.append(app.services.validator.on_new_head)
     test_app.services.chain.chain = test.t.chain
-    # print("on_new_head is: {}".format(test_app.services.chain.on_new_head_cbs))
-    # test_app.services.chain.on_new_head_cbs(app.services.validator)
-    # test_app.services.validator.chain = test.t.chain
-    # test_app.services.validator.chain.on_new_head_cbs.append(app.services.validator.on_new_head)
     test.parse('B1')
-    # test_chain = tester.Chain()
-    # test_chain.mine(30)
-    # test_app.mine_next_block()
 
     assert True

--- a/pyethapp/tests/test_validator_service.py
+++ b/pyethapp/tests/test_validator_service.py
@@ -5,6 +5,7 @@ import tempfile
 from devp2p.service import BaseService
 from ethereum.config import default_config
 from pyethapp.config import update_config_with_defaults, get_default_config
+from ethereum.pow.ethpow import mine
 from ethereum.slogging import get_logger, configure_logging
 from ethereum.hybrid_casper import chain as hybrid_casper_chain
 from ethereum.tools import tester
@@ -12,43 +13,13 @@ from ethereum.tests.hybrid_casper.testing_lang import TestLangHybrid
 from ethereum.utils import encode_hex
 from pyethapp.app import EthApp
 from pyethapp.db_service import DBService
+from pyethapp.eth_service import ChainService
 from pyethapp.accounts import Account, AccountsService
 from pyethapp.validator_service import ValidatorService
 from pyethapp.pow_service import PoWService
 
 log = get_logger('tests.validator_service')
-configure_logging('validator:debug,eth.chainservice:debug,eth.pb.tx:debug')
-
-class ChainServiceMock(BaseService):
-    name = 'chain'
-
-    def __init__(self, app, test):
-        super(ChainServiceMock, self).__init__(app)
-
-        class InnerNewHeadCbsMock(object):
-            def __init__(self, outer):
-                self.outer = outer
-
-            def append(self, cb):
-                self.outer.chain.new_head_cb = cb
-
-        # Save as interface to tester
-        self.test = test
-        self.on_new_head_cbs = InnerNewHeadCbsMock(self)
-        # self.chain = hybrid_casper_chain.Chain(genesis=test.genesis, new_head_cb=self.app.services.validator.on_new_head)
-        self.chain = hybrid_casper_chain.Chain(genesis=test.genesis)
-        self.is_syncing = False
-
-    def add_transaction(self, tx):
-        # Relay transactions into the tester for mining
-        return self.test.t.direct_tx(tx)
-
-    # Override this classmethod and add another arg
-    @classmethod
-    def register_with_app(klass, app, test):
-        s = klass(app, test)
-        app.register_service(s)
-        return s
+configure_logging('validator:debug,eth.chainservice:debug')
 
 class PeerManagerMock(BaseService):
     name = 'peermanager'
@@ -57,11 +28,47 @@ class PeerManagerMock(BaseService):
         pass
 
 @pytest.fixture()
-def test():
-    return TestLangHybrid(5, 25, 0.02, 0.002)
+def test_app(request, tmpdir):
+    class TestApp(EthApp):
+        def mine_blocks(self, n):
+            for i in range(0, n):
+                self.mine_one_block()
 
-@pytest.fixture()
-def test_app(request, tmpdir, test):
+        def mine_epoch(self):
+            epoch_length = self.config['eth']['block']['EPOCH_LENGTH']
+            return self.mine_blocks(epoch_length)
+
+        def mine_one_block(self):
+            """Mine until a valid nonce is found.
+            :returns: the new head
+            """
+            log.debug('mining next block')
+            block = self.services.chain.head_candidate
+            chain = self.services.chain.chain
+            head_number = chain.head.number
+            delta_nonce = 10**6
+            for start_nonce in count(0, delta_nonce):
+                bin_nonce, mixhash = mine(block.number, block.difficulty, block.mining_hash,
+                                            start_nonce=start_nonce, rounds=delta_nonce)
+                if bin_nonce:
+                    break
+            self.services.chain.add_mined_block(block)
+            self.services.pow.recv_found_nonce(bin_nonce, mixhash, block.mining_hash)
+            if len(chain.time_queue) > 0:
+                # If we mine two blocks within one second, pyethereum will
+                # force the new block's timestamp to be in the future (see
+                # ethereum1_setup_block()), and when we try to add that block
+                # to the chain (via Chain.add_block()), it will be put in a
+                # queue for later processing. Since we need to ensure the
+                # block has been added before we continue the test, we
+                # have to manually process the time queue.
+                log.debug('block mined too fast, processing time queue')
+                chain.process_time_queue(new_time=block.timestamp)
+            log.debug('block mined')
+            assert chain.head.difficulty == 1
+            assert chain.head.number == head_number + 1
+            return chain.head
+
     config = {
         'data_dir': str(tmpdir),
         'db': {'implementation': 'EphemDB'},
@@ -80,38 +87,41 @@ def test_app(request, tmpdir, test):
                 'BASE_PENALTY_FACTOR': 0.002,
             }
         },
-        # 'genesis_data': {},
         'validate': [encode_hex(tester.accounts[0])],
     }
 
     services = [
         DBService,
+        ChainService,
+        PoWService,
         PeerManagerMock,
         ValidatorService,
         ]
-    update_config_with_defaults(config, get_default_config([EthApp] + services))
+    update_config_with_defaults(config, get_default_config([TestApp] + services))
     update_config_with_defaults(config, {'eth': {'block': default_config}})
-    app = EthApp(config)
+    app = TestApp(config)
 
     # Add AccountsService first and initialize with coinbase account
     AccountsService.register_with_app(app)
     app.services.accounts.add_account(Account.new('', tester.keys[0]), store=False)
-
-    # Need to do this one manually too
-    ChainServiceMock.register_with_app(app, test)
 
     for service in services:
         service.register_with_app(app)
 
     return app
 
-def test_generate_valcode(test, test_app):
-    # Link the mock ChainService to the tester object. This is the interface between
-    # pyethapp and pyethereum's test interface.
+def test_generate_valcode(test_app):
+    epoch_length = test_app.config['eth']['block']['EPOCH_LENGTH']
 
-    # Create a smart chain object: this ties the chain used in the tester
-    # to the validator chain.
-    test_app.chain = test.t.chain = test_app.services.chain.chain
-    test.parse('B B B')
+    # This block should cause the validator to send the valcode tx
+    # This block should cause the validator to send the deposit tx
+    # In this block the validator should be active woop woop
+    test_app.mine_blocks(3)
+
+    # Move to the next epoch
+    test_app.mine_epoch()
+    test_app.mine_epoch()
+    test_app.mine_epoch()
+    # test_app.mine_blocks(1)
 
     assert True

--- a/pyethapp/validator_service.py
+++ b/pyethapp/validator_service.py
@@ -155,10 +155,8 @@ class ValidatorService(BaseService):
             log.info('[hybrid_casper] Current epoch: {} - Current dynasty: {} - Start dynasty: {} - End dynasty: {}'.format(
                 casper.get_current_epoch(),
                 casper.get_dynasty(),
-                "?",
-                "?",
-                # validator_info.start_dynasty,
-                # validator_info.end_dynasty,
+                casper.get_validators__start_dynasty(validator_index),
+                casper.get_validators__end_dynasty(validator_index),
             ))
             is_justified = casper.get_votes__is_justified(casper.get_current_epoch())
             is_finalized = casper.get_votes__is_finalized(casper.get_current_epoch()-1)
@@ -179,6 +177,7 @@ class ValidatorService(BaseService):
             log.info('[hybrid_casper] Not voting this round')
 
     def is_logged_in(self, casper, target_epoch, validator_index):
+        log.debug('[hybrid_casper] checking is_logged_in for target {} and vidx {}'.format(target_epoch, validator_index))
         start_dynasty = casper.get_validators__start_dynasty(validator_index)
         end_dynasty = casper.get_validators__end_dynasty(validator_index)
         current_dynasty = casper.get_dynasty_in_epoch(target_epoch)
@@ -249,9 +248,14 @@ class ValidatorService(BaseService):
         if self.valcode_addr is None:
             raise Exception('Valcode address not set')
         try:
-            return casper.get_validator_indexes(self.coinbase.address)
+            vidx = casper.get_validator_indexes(self.coinbase.address)
         except tester.TransactionFailed:
             return None
+
+        # Zero represents failure
+        if vidx == 0:
+            return None
+        return vidx
 
     def mk_transaction(self, to=b'\x00' * 20, value=0, data=b'',
                        gasprice=tester.GASPRICE, startgas=tester.STARTGAS, nonce=None):

--- a/pyethapp/validator_service.py
+++ b/pyethapp/validator_service.py
@@ -177,7 +177,6 @@ class ValidatorService(BaseService):
             log.info('[hybrid_casper] Not voting this round')
 
     def is_logged_in(self, casper, target_epoch, validator_index):
-        log.debug('[hybrid_casper] checking is_logged_in for target {} and vidx {}'.format(target_epoch, validator_index))
         start_dynasty = casper.get_validators__start_dynasty(validator_index)
         end_dynasty = casper.get_validators__end_dynasty(validator_index)
         current_dynasty = casper.get_dynasty_in_epoch(target_epoch)

--- a/pyethapp/validator_service.py
+++ b/pyethapp/validator_service.py
@@ -134,10 +134,13 @@ class ValidatorService(BaseService):
 
     def generate_vote_message(self):
         state = self.chain.state.ephemeral_clone()
-        # TODO: Add logic which waits until a specific blockheight before submitting vote, something like:
-        # if state.block_number % self.epoch_length < 1:
-        #     return None
         target_epoch = state.block_number // self.epoch_length
+        # Wait until a specific blockheight before submitting vote
+        wait_blocks = self.epoch_length // 4
+        epoch_block_number = state.block_number % self.epoch_length
+        if epoch_block_number < wait_blocks:
+            log.info('[hybrid_casper] Waiting for epoch block {} to submit vote, now block {}'.format(wait_blocks, epoch_block_number))
+            return None
         # NO_DBL_VOTE: Don't vote if we have already
         if target_epoch in self.votes:
             log.info('[hybrid_casper] Already voted for this epoch as target ({}), not voting again'.format(target_epoch))

--- a/pyethapp/validator_service.py
+++ b/pyethapp/validator_service.py
@@ -41,13 +41,13 @@ class ValidatorService(BaseService):
         else:
             self.validating = False
 
-        app.services.chain.on_new_head_cbs.append(self.on_new_head)
+        self.chainservice.on_new_head_cbs.append(self.on_new_head)
 
     def on_new_head(self, block):
         if not self.validating:
             log.info('[hybrid_casper] not validating, not updating')
             return
-        if self.app.services.chain.is_syncing:
+        if self.chainservice.is_syncing:
             log.info('[hybrid_casper] chain syncing, not updating')
             return
         self.update()
@@ -95,7 +95,7 @@ class ValidatorService(BaseService):
         if not logout_success:
             raise Exception('Logout tx failed')
         log.info('[hybrid_casper] Broadcasting logout tx: {}'.format(str(logout_tx)))
-        self.chainservice.broadcast_transaction(logout_tx)
+        self.chainservice.add_transaction(logout_tx)
 
     def update(self):
         log.info('[hybrid_casper] validator {} updating'.format(self))
@@ -112,7 +112,7 @@ class ValidatorService(BaseService):
         elif not self.valcode_tx:
             self.generate_valcode_tx()
             log.info('[hybrid_casper] Broadcasting valcode tx and waiting for it to be mined')
-            self.chainservice.broadcast_transaction(self.valcode_tx)
+            self.chainservice.add_transaction(self.valcode_tx)
 
             # Wait for it to be mined
             return
@@ -126,7 +126,7 @@ class ValidatorService(BaseService):
         elif not self.did_broadcast_deposit:
             self.generate_deposit_tx()
             log.info('[hybrid_casper] Broadcasting deposit tx')
-            self.chainservice.broadcast_transaction(self.deposit_tx)
+            self.chainservice.add_transaction(self.deposit_tx)
             self.did_broadcast_deposit = True
 
             # Wait for it to be mined
@@ -155,7 +155,7 @@ class ValidatorService(BaseService):
         if vote_msg:
             vote_tx = self.mk_vote_tx(vote_msg)
             log.info('[hybrid_casper] Broadcasting vote: {}'.format(str(vote_tx)))
-            self.chainservice.broadcast_transaction(vote_tx)
+            self.chainservice.add_transaction(vote_tx)
         else:
             log.info('[hybrid_casper] Not voting this round')
 

--- a/pyethapp/validator_service.py
+++ b/pyethapp/validator_service.py
@@ -34,7 +34,6 @@ class ValidatorService(BaseService):
         self.latest_target_epoch = -1
         self.latest_source_epoch = -1
         self.epoch_length = self.chain.env.config['EPOCH_LENGTH']
-        # self.chain.time = lambda: int(time.time())
 
         if app.config['validate']:
             self.coinbase = app.services.accounts.find(app.config['validate'][0])
@@ -51,23 +50,25 @@ class ValidatorService(BaseService):
             return
         self.update()
 
-    def broadcast_deposit(self):
-        if not self.valcode_tx or not self.deposit_tx:
-            nonce = self.chain.state.get_nonce(self.coinbase.address)
-            # Generate transactions
-            valcode_tx = self.mk_validation_code_tx(nonce)
-            valcode_addr = utils.mk_contract_address(self.coinbase.address, nonce)
-            deposit_tx = self.mk_deposit_tx(self.deposit_size, valcode_addr, nonce+1)
-            # Verify the transactions pass
-            temp_state = self.chain.state.ephemeral_clone()
-            valcode_success, o1 = apply_transaction(temp_state, valcode_tx)
-            deposit_success, o2 = apply_transaction(temp_state, deposit_tx)
-            self.valcode_tx = valcode_tx
-            log.info('Valcode Tx generated: {}'.format(str(valcode_tx)))
-            self.valcode_addr = valcode_addr
-            self.deposit_tx = deposit_tx
-            log.info('Deposit Tx generated: {}'.format(str(deposit_tx)))
-        self.chainservice.broadcast_transaction(valcode_tx)
+    def generate_valcode_and_deposit_tx(self):
+        nonce = self.chain.state.get_nonce(self.coinbase.address)
+        # Generate transactions
+        valcode_tx = self.mk_validation_code_tx(nonce)
+        valcode_addr = utils.mk_contract_address(self.coinbase.address, nonce)
+        deposit_tx = self.mk_deposit_tx(self.deposit_size, valcode_addr, nonce+1)
+        # Verify the transactions pass
+        temp_state = self.chain.state.ephemeral_clone()
+        valcode_success, o1 = apply_transaction(temp_state, valcode_tx)
+        deposit_success, o2 = apply_transaction(temp_state, deposit_tx)
+
+        # We should never generate invalid txs
+        assert valcode_success and deposit_success
+
+        self.valcode_tx = valcode_tx
+        log.info('Valcode Tx generated: {}'.format(str(valcode_tx)))
+        self.valcode_addr = valcode_addr
+        self.deposit_tx = deposit_tx
+        log.info('Deposit Tx generated: {}'.format(str(deposit_tx)))
 
     def broadcast_logout(self, login_logout_flag):
         epoch = self.chain.state.block_number // self.epoch_length
@@ -80,45 +81,94 @@ class ValidatorService(BaseService):
         temp_state = self.chain.state.ephemeral_clone()
         logout_success, o1 = apply_transaction(temp_state, logout_tx)
         if not logout_success:
-            raise Exception('Valcode tx or deposit tx failed')
-        log.info('Login/logout Tx generated: {}'.format(str(logout_tx)))
+            raise Exception('Logout tx failed')
+        log.info('[hybrid_casper] Broadcasting logout tx: {}'.format(str(logout_tx)))
         self.chainservice.broadcast_transaction(logout_tx)
 
     def update(self):
         if self.chain.state.get_balance(self.coinbase.address) < self.deposit_size:
-            log.info('Cannot login as validator: Not enough ETH!')
+            log.info('[hybrid_casper] Cannot login as validator: insufficient balance')
             return
         if not self.valcode_tx or not self.deposit_tx:
-            self.broadcast_deposit()
-        if not self.has_broadcasted_deposit and self.chain.state.get_code(self.valcode_addr):
-            log.info('Found code!')
+            self.generate_valcode_and_deposit_tx()
+            self.chainservice.broadcast_transaction(self.valcode_tx)
+        # LANE Can't this be done synchronously after generating the deposit tx?
+        # LANE: need to persist has_broadcasted_deposit so we don't do this twice
+        # Also need to allow login->logout->login, need to check if "logged in"
+        if  self.chain.state.get_code(self.valcode_addr) and not self.has_broadcasted_deposit:
+            log.info('[hybrid_casper] Broadcasting deposit tx')
             self.chainservice.broadcast_transaction(self.deposit_tx)
             self.has_broadcasted_deposit = True
-        log.info('Validator index: {}'.format(self.get_validator_index(self.chain.state)))
+        log.info('[hybrid_casper] Validator index: {}'.format(self.get_validator_index(self.chain.state)))
 
         casper = tester.ABIContract(tester.State(self.chain.state.ephemeral_clone()), casper_utils.casper_abi,
                                     self.chain.casper_address)
         try:
-            log.info('&&& '.format())
-            log.info('Vote percent: {} - Deposits: {} - Recommended Source: {} - Current Epoch: {}'
+            log.info('[hybrid_casper] Vote percent: {} - Deposits: {} - Recommended Source: {} - Current Epoch: {}'
                      .format(casper.get_main_hash_voted_frac(), casper.get_total_curdyn_deposits(),
                              casper.get_recommended_source_epoch(), casper.get_current_epoch()))
             is_justified = casper.get_votes__is_justified(casper.get_current_epoch())
             is_finalized = casper.get_votes__is_finalized(casper.get_current_epoch()-1)
             if is_justified:
-                log.info('Justified epoch: {}'.format(casper.get_current_epoch()))
+                log.info('[hybrid_casper] Justified epoch: {}'.format(casper.get_current_epoch()))
             if is_finalized:
-                log.info('Finalized epoch: {}'.format(casper.get_current_epoch()-1))
-        except:
-            log.info('&&& Vote frac failed')
+                log.info('[hybrid_casper] Finalized epoch: {}'.format(casper.get_current_epoch()-1))
+        except e:
+            log.info('[hybrid_casper] Vote frac failed: {}'.format(e))
 
-        # Vote
         # Generate vote messages and broadcast if possible
         vote_msg = self.generate_vote_message()
         if vote_msg:
             vote_tx = self.mk_vote_tx(vote_msg)
+            log.info('[hybrid_casper] Broadcasting vote: {}'.format(str(vote_tx)))
             self.chainservice.broadcast_transaction(vote_tx)
-            log.info('Sent vote! Tx: {}'.format(str(vote_tx)))
+
+    def is_logged_in(self, casper, target_epoch, validator_index):
+        start_dynasty = casper.get_validators__start_dynasty(validator_index)
+        end_dynasty = casper.get_validators__end_dynasty(validator_index)
+        current_dynasty = casper.get_dynasty_in_epoch(target_epoch)
+        past_dynasty = current_dynasty - 1
+        in_current_dynasty = ((start_dynasty <= current_dynasty) and (current_dynasty < end_dynasty))
+        in_prev_dynasty = ((start_dynasty <= past_dynasty) and (past_dynasty < end_dynasty))
+        return (in_current_dynasty or in_prev_dynasty)
+
+    def generate_vote_message(self):
+        state = self.chain.state.ephemeral_clone()
+        # TODO: Add logic which waits until a specific blockheight before submitting vote, something like:
+        # if state.block_number % self.epoch_length < 1:
+        #     return None
+        target_epoch = state.block_number // self.epoch_length
+        # NO_DBL_VOTE: Don't vote if we have already
+        if target_epoch in self.votes:
+            log.info('[hybrid_casper] Already voted for this epoch as target ({}), not voting again'.format(target_epoch))
+            return None
+        # Create a Casper contract which we can use to get related values
+        casper = tester.ABIContract(tester.State(state), casper_utils.casper_abi, self.chain.casper_address)
+        # Get the ancestry hash and source ancestry hash
+        validator_index = self.get_validator_index(state)
+        target_hash, target_epoch, source_epoch = self.get_recommended_casper_msg_contents(casper, validator_index)
+        if target_hash is None:
+            log.info('[hybrid_casper] Failed to get target hash, not voting')
+            return None
+        # Prevent NO_SURROUND slash. Note that this is a little over-conservative and thus suboptimal.
+        # It strictly only allows votes for later sources and targets than we've already voted for.
+        # It avoids voting in (rare) cases where it would be safe to do so, e.g., with an earlier
+        # source _and_ an earlier target.
+        if target_epoch < self.latest_target_epoch or source_epoch < self.latest_source_epoch:
+            log.info('[hybrid_casper] Not voting to avoid NO_SURROUND slash')
+            return None
+        # Assert that we are logged in
+        if not self.is_logged_in(casper, target_epoch, validator_index):
+            log.info('[hybrid_casper] Validator not logged in, not voting')
+            return None
+        vote_msg = casper_utils.mk_vote(validator_index, target_hash, target_epoch, source_epoch, self.coinbase.privkey)
+        # Save the vote message we generated
+        self.votes[target_epoch] = vote_msg
+        self.latest_target_epoch = target_epoch
+        self.latest_source_epoch = source_epoch
+        log.info('[hybrid_casper] Generated vote: validator %d - epoch %d - source_epoch %d - hash %s' %
+                 (self.get_validator_index(state), target_epoch, source_epoch, utils.encode_hex(target_hash)))
+        return vote_msg
 
     def get_recommended_casper_msg_contents(self, casper, validator_index):
         current_epoch = casper.get_current_epoch()
@@ -134,49 +184,6 @@ class ValidatorService(BaseService):
         if epoch == 0:
             return b'\x00' * 32
         return self.chain.get_block_by_number(epoch*self.epoch_length-1).hash
-
-    def is_logged_in(self, casper, target_epoch, validator_index):
-        start_dynasty = casper.get_validators__start_dynasty(validator_index)
-        end_dynasty = casper.get_validators__end_dynasty(validator_index)
-        current_dynasty = casper.get_dynasty_in_epoch(target_epoch)
-        past_dynasty = current_dynasty - 1
-        in_current_dynasty = ((start_dynasty <= current_dynasty) and (current_dynasty < end_dynasty))
-        in_prev_dynasty = ((start_dynasty <= past_dynasty) and (past_dynasty < end_dynasty))
-        if not (in_current_dynasty or in_prev_dynasty):
-            return False
-        return True
-
-    def generate_vote_message(self):
-        state = self.chain.state.ephemeral_clone()
-        epoch = state.block_number // self.epoch_length
-        # TODO: Add logic which waits until a specific blockheight before submitting vote, something like:
-        # if state.block_number % self.epoch_length < 1:
-        #     return None
-        # NO_DBL_VOTE: Don't vote if we have already
-        if epoch in self.votes:
-            return None
-        # Create a Casper contract which we can use to get related values
-        casper = tester.ABIContract(tester.State(state), casper_utils.casper_abi, self.chain.casper_address)
-        # Get the ancestry hash and source ancestry hash
-        validator_index = self.get_validator_index(state)
-        target_hash, epoch, source_epoch = self.get_recommended_casper_msg_contents(casper, validator_index)
-        if target_hash is None:
-            return None
-        # Prevent NO_SURROUND slash
-        if epoch < self.latest_target_epoch or source_epoch < self.latest_source_epoch:
-            return None
-        # Verify that we are either in the current dynasty or prev dynasty --     assert in_current_dynasty or in_prev_dynasty
-        if not self.is_logged_in(casper, epoch, validator_index):
-            log.info('Validator not logged in yet!')
-            return None
-        vote_msg = casper_utils.mk_vote(validator_index, target_hash, epoch, source_epoch, self.coinbase.privkey)
-        # Save the vote message we generated
-        self.votes[epoch] = vote_msg
-        self.latest_target_epoch = epoch
-        self.latest_source_epoch = source_epoch
-        log.info('Vote submitted: validator %d - epoch %d - source_epoch %d - hash %s' %
-                 (self.get_validator_index(state), epoch, source_epoch, utils.encode_hex(target_hash)))
-        return vote_msg
 
     def get_validator_index(self, state):
         t = tester.State(state.ephemeral_clone())

--- a/pyethapp/validator_service.py
+++ b/pyethapp/validator_service.py
@@ -45,8 +45,10 @@ class ValidatorService(BaseService):
 
     def on_new_head(self, block):
         if not self.validating:
+            log.info('[hybrid_casper] not validating, not updating')
             return
         if self.app.services.chain.is_syncing:
+            log.info('[hybrid_casper] chain syncing, not updating')
             return
         self.update()
 
@@ -96,6 +98,7 @@ class ValidatorService(BaseService):
         self.chainservice.broadcast_transaction(logout_tx)
 
     def update(self):
+        log.info('[hybrid_casper] validator {} updating'.format(self))
         # Make sure we have enough ETH to deposit
         if self.chain.state.get_balance(self.coinbase.address) < self.deposit_size:
             log.info('[hybrid_casper] Cannot login as validator: insufficient balance')


### PR DESCRIPTION
This PR is not meant to be merged, at least not yet. I thought it would make sense to move the discussions we've been having on various other channels inline into Github, which makes it easier to loop others in, reference specific lines of code, etc. It may make sense to submit smaller individual PRs when this code is ready to be merged.

As you can see in this PR, I cleaned up `validator_service.py` quite a bit along the lines discussed in the [Hybrid Casper testnet next steps doc](http://notes.ethresear.ch/GYIwnArAxgzA7AEwLQCYVxEgLHAHCpAQ0JGSzFwFMAGQiARnwRiA?both). I also added a `test_validator_service.py` module.

@karlfloersch you recommended that we use https://github.com/karlfloersch/pyethereum/blob/develop/ethereum/tests/hybrid_casper/testing_lang.py and https://github.com/karlfloersch/pyethereum/blob/develop/ethereum/tools/tester.py to test the validator service. I spent a lot of time working on this for the past couple of days, and got pretty far, but I'm stuck on the fact that transactions coming from the validator service (e.g. https://github.com/lrettig/pyethapp/blob/73eaab6825cdcff73caf2bfa0414982cb31e6847/pyethapp/validator_service.py#L115) never make it into the chain state, causing checks such as https://github.com/lrettig/pyethapp/blob/73eaab6825cdcff73caf2bfa0414982cb31e6847/pyethapp/validator_service.py#L121 to always fail.

I suspect this has to do with the `ephemeral_clone` operation at https://github.com/karlfloersch/pyethereum/blob/5a4d247bb9c6bbed9c5c6357ea95203d2d9c6805/ethereum/tools/tester.py#L172 but I'm not sure.

Could you explain why you think we need to test the validator service using the tester/testing_lang harness from pyethereum?