### PR TITLE
Mine to coinbase instead of 0x3535

### DIFF
--- a/pyethapp/eth_service.py
+++ b/pyethapp/eth_service.py
@@ -165,11 +165,11 @@ class ChainService(WiredService):
 
         super(ChainService, self).__init__(app)
         log.info('initializing chain')
-        coinbase = app.services.accounts.coinbase
+        self.coinbase = app.services.accounts.coinbase
         # TODO: Generate an env based on the `sce['block']` and use that to create the state
         # env = Env(self.db, sce['block'])
         genesis_data = casper_utils.make_casper_genesis({}, 50, 5, 0.1, 0.0001, genesis_declaration=sce.get('genesis_data', {}), db=self.db)
-        self.chain = Chain(genesis=genesis_data, reset_genesis=False, coinbase=coinbase, new_head_cb=self._on_new_head, env=genesis_data.env)
+        self.chain = Chain(genesis=genesis_data, reset_genesis=False, coinbase=self.coinbase, new_head_cb=self._on_new_head, env=genesis_data.env)
         header = self.chain.state.prev_headers[0]
         log.info('chain at', number=header.number)
         if 'genesis_hash' in sce:
@@ -242,7 +242,7 @@ class ChainService(WiredService):
             # make_head_candidate modifies it.
             txqueue = copy.deepcopy(self.transaction_queue)
             self._head_candidate, self._head_candidate_state = make_head_candidate(
-                self.chain, txqueue, timestamp=int(time.time() - 1))
+                self.chain, txqueue, timestamp=int(time.time() - 1), coinbase=self.coinbase)
         return self._head_candidate
 
     def add_transaction(self, tx, origin=None, force_broadcast=False, force=False):


### PR DESCRIPTION
This fixes what is causing all the mining on the testnet to go to 0x353535 by passing coinbase into `make_head_candidate` so does not default to 0x35

Not sure if I should be merging into here or the main repo. going to do both

  